### PR TITLE
Update to ngircd 25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM ubuntu
+FROM ubuntu:19.04
 
 MAINTAINER Jason Carver <ut96caarrs@snkmail.com>
 
-# RUN apt-get update && apt-get install apt-transport-https
-
-# RUN echo "deb https://archive.ubuntu.com/ubuntu precise main universe" >> /etc/apt/sources.list
-
 RUN apt-get update && \
-  apt-get install -y apt-transport-https busybox-syslogd ngircd
+  apt-get install -y apt-utils # install apt-utils first or apt will complain
+
+RUN apt-get install -y apt-transport-https busybox-syslogd=1:1.27.2-2ubuntu7 ngircd=25-2
 
 # expose IRC ports
 EXPOSE :443

--- a/ngircd.conf
+++ b/ngircd.conf
@@ -17,7 +17,7 @@
 
 	# Text file which contains the ngIRCd help text. This file is required
 	# to display help texts when using the "HELP <cmd>" command.
-	;HelpFile = /usr/local/share/doc/ngircd/Commands.txt
+	;HelpFile = :DOCDIR:/Commands.txt
 
 	# Info text of the server. This will be shown by WHOIS and
 	# LINKS requests for example.
@@ -27,14 +27,20 @@
 	# listen. Default values are:
 	# "0.0.0.0" or (if compiled with IPv6 support) "::,0.0.0.0"
 	# so the server listens on all IP addresses of the system by default.
-	Listen = 127.0.0.1,192.168.0.1
+	;Listen = 127.0.0.1,192.168.0.1
 
 	# Text file with the "message of the day" (MOTD). This message will
 	# be shown to all users connecting to the server:
-	;MotdFile = /usr/local/etc/ngircd.motd
+	;MotdFile = :ETCDIR:/ngircd.motd
 
-	# A simple Phrase (<256 chars) if you don't want to use a motd file.
+	# A simple Phrase (<127 chars) if you don't want to use a motd file.
 	;MotdPhrase = "Hello world!"
+
+	# The name of the IRC network to which this server belongs. This name
+	# is optional, should only contain ASCII characters, and can't contain
+	# spaces. It is only used to inform clients. The default is empty,
+	# so no network name is announced to clients.
+	;Network = aIRCnetwork
 
 	# Global password for all users needed to connect to the server.
 	# (Default: not set)
@@ -94,6 +100,12 @@
 	;MaxNickLength = 9
 	MaxNickLength = 30
 
+	# Maximum penalty time increase in seconds, per penalty event. Set to -1
+	# for no limit (the default), 0 to disable penalties altogether. The
+	# daemon doesn't use penalty increases higher than 2 seconds during
+	# normal operation, so values greater than 1 rarely make sense.
+	;MaxPenaltyTime = -1
+
 	# Maximum number of channels returned in response to a /list
 	# command (0: unlimited):
 	;MaxListSize = 100
@@ -149,8 +161,8 @@
 	;ConnectIPv4 = yes
 
 	# Default user mode(s) to set on new local clients. Please note that
-	# only modes can be set that the client could set on itself, you can't
-	# set "a" (away) or "o" (IRC Op), for example! Default: none.
+	# only modes can be set that the client could set using regular MODE
+	# commands, you can't set "a" (away) for example! Default: none.
 	;DefaultUserModes = i
 
 	# Do DNS lookups when a client connects to the server.
@@ -163,16 +175,16 @@
 
 	# Directory containing configuration snippets (*.conf), that should
 	# be read in after parsing this configuration file.
-	;IncludeDir = /usr/local/etc/conf.d
+	;IncludeDir = :ETCDIR:/conf.d
 
 	# Enhance user privacy slightly (useful for IRC server on TOR or I2P)
 	# by censoring some information like idle time, logon time, etc.
 	;MorePrivacy = no
 
 	# Normally ngIRCd doesn't send any messages to a client until it is
-	# registered. Enable this option to let the daemon send "NOTICE AUTH"
+	# registered. Enable this option to let the daemon send "NOTICE *"
 	# messages to clients while connecting.
-	;NoticeAuth = no
+	;NoticeBeforeRegistration = no
 
 	# Should IRC Operators be allowed to use the MODE command even if
 	# they are not(!) channel-operators?
@@ -201,7 +213,19 @@
 	# same time, because you wouldn't be able to distinguish between
 	# Ident'ified and PAM-authenticated users: both don't have a "~"
 	# character prepended to their respective user names!
-	;PAMIsOptional = no
+	#
+	# Since this configuration is for testing rather than production
+	# we make PAM optional
+	PAMIsOptional = yes
+
+	# When PAM is enabled, this value determines the used PAM
+	# configuration.
+	# This setting allows to run multiple ngIRCd instances with
+	# different PAM configurations on each instance.
+	# If you set it to "ngircd-foo", PAM will use
+	# /etc/pam.d/ngircd-foo instead of the default
+	# /etc/pam.d/ngircd.
+	;PAMServiceName = ngircd
 
 	# Let ngIRCd send an "authentication PING" when a new client connects,
 	# and register this client only after receiving the corresponding
@@ -229,22 +253,22 @@
 	# So don't forget to remove the ";" above if this is the case ...
 
 	# SSL Server Key Certificate
-	;CertFile = /usr/local/etc/ssl/server-cert.pem
+	;CertFile = :ETCDIR:/ssl/server-cert.pem
 
 	# Select cipher suites allowed for SSL/TLS connections. This defaults
 	# to HIGH:!aNULL:@STRENGTH (OpenSSL) or SECURE128 (GnuTLS).
 	# See 'man 1ssl ciphers' (OpenSSL) or 'man 3 gnutls_priority_init'
 	# (GnuTLS) for details.
 	# For OpenSSL:
-	;CipherList = HIGH:!aNULL:@STRENGTH
+	;CipherList = HIGH:!aNULL:@STRENGTH:!SSLv3
 	# For GnuTLS:
-	;CipherList = SECURE128
+	;CipherList = SECURE128:-VERS-SSL3.0
 
 	# Diffie-Hellman parameters
-	;DHFile = /usr/local/etc/ssl/dhparams.pem
+	;DHFile = :ETCDIR:/ssl/dhparams.pem
 
 	# SSL Server Key
-	;KeyFile = /usr/local/etc/ssl/server-key.pem
+	;KeyFile = :ETCDIR:/ssl/server-key.pem
 
 	# password to decrypt SSLKeyFile (OpenSSL only)
 	;KeyFilePassword = secret
@@ -271,7 +295,7 @@
 [Server]
 	# Other servers are configured in [Server] sections. If you
 	# configure a port for the connection, then this ngircd tries to
-	# connect to to the other server on the given port; if not it waits
+	# connect to the other server on the given port; if not it waits
 	# for the other server to connect.
 	# There may be more than one server block, one for each server.
 	#
@@ -355,7 +379,7 @@
 
 	# Key file, syntax for each line: "<user>:<nick>:<key>".
 	# Default: none.
-	;KeyFile = /usr/local/etc/#chan.key
+	;KeyFile = :ETCDIR:/#chan.key
 
 	# maximum users per channel (mode l)
 	;MaxUsers = 23

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# starting the busybox-syslogd service directly doesn't work
+# but we can start the daemon directly:
+syslogd
+
 service ngircd start
-tail -f /var/log/syslog
+tail -f /var/log/messages


### PR DESCRIPTION
This updates the image to the latest ngircd version. I found it easiest to just go to a newer version of ubuntu for this since the default repository contains the newest version:

https://packages.ubuntu.com/search?keywords=ngircd&searchon=names

I updated the configuration with the changes in the latest sample configuration from the ngircd project. I went back to the default IP binding since ngircd was complaining about being unable to bind to 192.168.0.1 on startup. I also made PAM optional since otherwise unregistered access would no longer be possible. All other settings remain unchanged/default.

Unfortunately, busybox-syslogd behaves differently now. Something in the installation doesn't work quite as intended. I found that this can be easily worked around by just starting syslogd manually. Although probably not intended, this works just fine. The place where it writes the log also changed for whatever reason.